### PR TITLE
Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ allprojects {
 2. Add the dependency to your app's build.gradle
 ```gradle
 dependencies {
-        implementation 'com.github.evilthreads669966:bootlaces:4.1.1'
+        implementation 'com.github.evilthreads669966:bootlaces:4.2'
         //if you are using LifecycleBootService you need to include this library        
         implementation 'androidx.lifecycle:lifecycle-service:2.2.0'
 }
@@ -50,18 +50,18 @@ class MyService : LifecycleBootService() {
 ```kotlin
 //this is the minimal requirement to get Boot Laces running
 startBoot(this){
-    service = LockService::class
+    service = LockService::class.qualifiedName
 }
 ```
 6. Initialize the properties of your persistent foreground notification within bootService's lambda. If you are only supporting Oreo and up then you do not need a Build.Version check.
 ```kotlin
 startBoot(this){
-    service = LockService::class
+    service = LockService::class.qualifiedName
     if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-        //noPress is for whether you want your notification to bring up an Activity when pressed
-        noPress = true
-        notificationTitle = "I LOVE YOU"
-        notificationContent = "Evil Threads loves you!"
+        //the activity to place inside the pending intent for your notification when selected. This activity will launch.
+        activity = MyActivity::class.qualifiedName
+        title = "I LOVE YOU"
+        content = "Evil Threads loves you!"
     }
 }
 
@@ -71,14 +71,15 @@ val myPayload = suspend {
     //do something
 }
 startBoot(this, payload = myPayload){
-    service = LockService::class
+    service = LockService::class.qualifiedName
 }
 ```
 7. Update your notification by passing any context as an argument to bootNotificaton and then initializing its' properties inside of the lambda.
 ```kotlin
 updateBoot(ctx){
-    notificationTitle = "I HATE YOU"
-    notificationContent = "Evil Threads hates you!"
+    title = "I HATE YOU"
+    content = "Evil Threads hates you!"
+    icon = android.R.drawable.presence_online
 }
 ```
 ## Important To Know

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <service android:name=".LockService" android:directBootAware="true" android:foregroundServiceType="dataSync" />
+        <service android:name=".LockService"
+            android:directBootAware="true"
+            android:foregroundServiceType="dataSync"
+            />
         <activity
             android:name=".LockScreenActivity"
             android:launchMode="singleInstance"

--- a/app/src/main/java/com/candroid/lacedboots/LockScreenObserver.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LockScreenObserver.kt
@@ -22,11 +22,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
-import com.candroid.bootlaces.Configuration
-import com.candroid.bootlaces.updateBoot
 import com.candroid.bootlaces.startBoot
+import com.candroid.bootlaces.updateBoot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+
 /*
             (   (                ) (             (     (
             )\ ))\ )    *   ) ( /( )\ )     (    )\ )  )\ )
@@ -54,12 +54,12 @@ class LockScreenObserver(val ctx: AppCompatActivity): LifecycleObserver {
 
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
     private fun startService(){
-        startBoot(ctx){
-            service = LockService::class
+        ctx.startBoot{
+            service = LockService::class.qualifiedName
             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-                noPress = true
-                notificationTitle = "I LOVE YOU"
-                notificationContent = "Evil Threads love you one time!"
+                title = "I LOVE YOU"
+                content = "Evil Threads love you one time!"
+                activity = LockScreenActivity::class.qualifiedName
             }
         }
         ctx.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -72,7 +72,7 @@ class LockScreenObserver(val ctx: AppCompatActivity): LifecycleObserver {
     private fun updateForegroundNotification(){
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             updateBoot(ctx){
-                notificationContent = "Evil Threads love you ${ScreenVisibility.count()} times!"
+                content = "Evil Threads love you ${ScreenVisibility.count()} times!"
             }
     }
 

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootNotificationFactory.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootNotificationFactory.kt
@@ -22,7 +22,6 @@ import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.flow.firstOrNull
-
 /*
             (   (                ) (             (     (
             )\ ))\ )    *   ) ( /( )\ )     (    )\ )  )\ )
@@ -103,12 +102,11 @@ internal class BootNotificationFactory(val ctx: Context){
         return null
     }
 
-    suspend fun updateForegroundNotification(title: String?, content: String?, icon: Int?) {
-        BootRepository.getInstance(ctx).saveBoot(null, null, title, content, icon)
+    suspend fun updateForegroundNotification(boot: Boot) {
+        BootRepository.getInstance(ctx).saveBoot(boot)
         val manager = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         manager.notify(Configuration.FOREGROUND_ID, createNotification())
     }
-
 
     private fun NotificationCompat.Builder.setContentIntent(activity: String) {
         val intent = Intent(ctx, Class.forName(activity)).apply {

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootRepository.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootRepository.kt
@@ -14,10 +14,8 @@ limitations under the License.*/
 package com.candroid.bootlaces
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.util.Log
 import androidx.datastore.DataStore
-import androidx.datastore.DataStoreFactory
 import androidx.datastore.preferences.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +24,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import java.io.File
 import java.io.IOException
-import java.lang.Exception
 
 /*
             (   (                ) (             (     (
@@ -98,13 +95,13 @@ internal class BootRepository(ctx: Context) {
         }
     }
 
-    suspend fun saveBoot(service: String?, activity: String?, title: String?, content: String?, icon: Int?) = dataStore.edit { prefs ->
-        service?.let { prefs[PREF_KEY_SERVICE] = service }
-        activity?.let { prefs[PREF_KEY_ACTIVITY] = activity }
-        title?.let { prefs[PREF_KEY_TITLE] = title }
-        content?.let { prefs[PREF_KEY_CONTENT] = content }
-        icon?.let { prefs[PREF_KEY_ICON] = icon }
+    suspend fun saveBoot(boot: Boot) = dataStore.edit { prefs ->
+        boot.service?.takeUnless { service -> service.equals(prefs[PREF_KEY_SERVICE]) }?.let { service -> prefs[PREF_KEY_SERVICE] = service }
+        boot.activity?.takeUnless { activity -> activity.equals(prefs[PREF_KEY_ACTIVITY]) }?.let { activity -> prefs[PREF_KEY_ACTIVITY] = activity }
+        boot.title?.takeUnless { title -> title.equals(prefs[PREF_KEY_TITLE]) }?.let { title -> prefs[PREF_KEY_TITLE] = title }
+        boot.content?.takeUnless { content -> content.equals(prefs[PREF_KEY_CONTENT]) }?.let { content -> prefs[PREF_KEY_CONTENT] = content }
+        boot.icon?.takeUnless { icon -> icon == prefs[PREF_KEY_ICON] }?.let { icon -> prefs[PREF_KEY_ICON] = icon }
     }
 }
-@PublishedApi
-internal data class Boot(var service: String? = null, var activity: String? = null, var title: String? = null, var content: String? = null, var icon: Int?  = null)
+
+data class Boot(var service: String? = null, var activity: String? = null, var title: String? = null, var content: String? = null, var icon: Int?  = null)


### PR DESCRIPTION
- Boot
  - Configuration is gone
    - notificationTitle, notificationContent, notificationIcon is now title, content, and icon
  - Boot does not have a noPress method
    - If you want to support launching an Activity when your boot notification is selected then you simply pass the name of your Activity.
    -  Boot has a property named activity for this
      - Activity is by default null and does not create a notification with a pending intent if so
