### PR TITLE
Remove Unnecessary BootRepository Transaction in startBoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ allprojects {
 2. Add the dependency to your app's build.gradle
 ```gradle
 dependencies {
-        implementation 'com.github.evilthreads669966:bootlaces:4.2'
+        implementation 'com.github.evilthreads669966:bootlaces:4.2.1'
         //if you are using LifecycleBootService you need to include this library        
         implementation 'androidx.lifecycle:lifecycle-service:2.2.0'
 }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootLaces.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootLaces.kt
@@ -55,14 +55,11 @@ inline fun Context.startBoot(noinline payload: ( suspend () -> Unit)? = null,  c
         throw InvalidParameterException("BootService is required by startBoot")
     runBlocking {
         BootRepository.getInstance(this@startBoot).saveBoot(boot)
-        val bootNotifConfig = BootRepository.getInstance(this@startBoot).loadBoot().firstOrNull()
-        if(bootNotifConfig?.service != null){
-            val intent = Intent(this@startBoot, Class.forName(bootNotifConfig.service!!))
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                startForegroundService(intent)
-            else
-                startService(intent)
-        }
+        val intent = Intent(this@startBoot, Class.forName(boot.service!!))
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            startForegroundService(intent)
+        else
+            startService(intent)
     }
 }
 

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootNotificationFactory.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootNotificationFactory.kt
@@ -102,7 +102,7 @@ internal class BootNotificationFactory(val ctx: Context){
         return null
     }
 
-    suspend fun updateForegroundNotification(boot: Boot) {
+    suspend fun updateBootNotification(boot: Boot) {
         BootRepository.getInstance(ctx).saveBoot(boot)
         val manager = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         manager.notify(Configuration.FOREGROUND_ID, createNotification())

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootService.kt
@@ -169,7 +169,7 @@ internal class NotificationProxy{
                     boot.icon = intent.getIntExtra(BootRepository.KEY_ICON, -1).takeIf { ic -> ic != -1 }
 
                 runBlocking {
-                    BootNotificationFactory.getInstance(ctx!!).updateForegroundNotification(boot)
+                    BootNotificationFactory.getInstance(ctx!!).updateBootNotification(boot)
                 }
             }
         }


### PR DESCRIPTION
- remove unnecessary transaction with BootRepository and unnecessary seceond instance of Boot in startBoot
- left it in on accident after Boot update for 4.2