### PR TITLE
BootException

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootException.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootException.kt
@@ -1,0 +1,3 @@
+package com.candroid.bootlaces
+
+class BootException: Exception("No boot service was found. Unable to start boot service. Please pass the name of your BootService to startBoot")

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootLaces.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootLaces.kt
@@ -48,11 +48,12 @@ import java.security.InvalidParameterException
  *
  * Starts your BootService and initalizes its' required configuration data for a foreground notification
  **/
+@Throws(BootException::class)
 inline fun Context.startBoot(noinline payload: ( suspend () -> Unit)? = null,  crossinline init: Boot.() -> Unit){
     LifecycleBootService.payload = payload
     val boot = Boot().apply { init() }
     if(boot.service == null)
-        throw InvalidParameterException("BootService is required by startBoot")
+        throw BootException()
     runBlocking {
         BootRepository.getInstance(this@startBoot).saveBoot(boot)
         val bootNotifConfig = BootRepository.getInstance(this@startBoot).loadBoot().firstOrNull()
@@ -78,3 +79,4 @@ inline fun updateBoot(ctx: Context, crossinline config: Boot.() -> Unit){
     }
     LocalBroadcastManager.getInstance(ctx).sendBroadcast(updateIntent)
 }
+


### PR DESCRIPTION
- BootException
  - allows me to let the user of my library know that their application is not going to perform as expected because they did not supply a the name of their BootService to startBoot