### PR TITLE
One Boot. No intent extras. Inline without exposing our Boot to the User with IBoot and IBootConfig

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/Boot.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Boot.kt
@@ -1,10 +1,68 @@
 package com.candroid.bootlaces
 
 /**
-* @author Chris Basinger
-* @email evilthreads669966@gmail.com
-* @date 10/09/20
+ * @author Chris Basinger
+ * @email evilthreads669966@gmail.com
+ * @date 10/09/20
  *
-* Boot holds all data related to a persistent background or foreground service.
-* */
-data class Boot(var service: String? = null, var activity: String? = null, var title: String? = null, var content: String? = null, var icon: Int?  = null)
+ * Boot holds all data related to a persistent background or foreground service.
+ * */
+
+/*IBoot and BootConfig were required because crossinline causes us to expose Boot outside the library and I don't want to expose internal sensitive data*/
+abstract class IBoot(open var service: String?, open var activity: String?, open var title: String?, open var content: String?, open var icon: Int?){
+    abstract fun edit(service: String? = null, activity: String? = null, title: String? = null, content: String? = null, icon: Int?  = null)
+    abstract fun <T: IBoot>edit(boot: T?)
+}
+
+class BootConfig(service: String? = null, activity: String? = null, title: String? = null, content: String? = null, icon: Int?  = null): IBoot(service, activity, title, content, icon) {
+    override fun edit(service: String?, activity: String?, title: String?, content: String?, icon: Int?) {
+        service?.let { this.service = it }
+        activity?.let { this.activity = it }
+        title?.let { this.title = it }
+        content?.let { this.content = it }
+        icon?.let { this.icon = it }
+    }
+
+    override fun <T : IBoot> edit(boot: T?) {
+        boot?.service?.let { this.service = it }
+        boot?.activity?.let { this.activity = it }
+        boot?.title?.let { this.title = it }
+        boot?.content?.let { this.content = it }
+        boot?.icon?.let { this.icon = it }
+    }
+}
+
+
+
+@PublishedApi
+internal class Boot(service: String? = null, activity: String? = null, title: String? = null, content: String? = null, icon: Int?  = null): IBoot(service, activity, title, content, icon){
+
+    @PublishedApi
+    internal  companion object Singleton{
+        private var INSTANCE: Boot? = null
+
+        @PublishedApi
+        @Synchronized
+        internal fun getInstance(): Boot{
+            if(INSTANCE == null)
+                INSTANCE = Boot()
+            return INSTANCE!!
+        }
+    }
+
+
+    override fun edit(service: String?, activity: String?, title: String?, content: String?, icon: Int?){
+        service?.let { this.service = it }
+        activity?.let { this.activity = it }
+        title?.let { this.title = it }
+        content?.let { this.content = it }
+        icon?.let { this.icon = it }
+    }
+
+    override fun <T: IBoot> edit(boot: T?) {
+        boot?.service?.let { this.service = it }
+        boot?.activity?.let { this.activity = it }
+        boot?.title?.let { this.title = it }
+        boot?.content?.let { this.content = it }
+        boot?.icon?.let { this.icon = it }    }
+}

--- a/bootlaces/src/main/java/com/candroid/bootlaces/NotificationProxy.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/NotificationProxy.kt
@@ -51,20 +51,9 @@ internal class NotificationProxy{
 
         override fun onReceive(ctx: Context?, intent: Intent?){
             if(intent?.action?.equals(Actions.ACTION_UPDATE) ?: false){
-                val boot = Boot()
-
-                if(intent!!.hasExtra(BootRepository.KEY_ACTIVITY))
-                    boot.activity = intent.getStringExtra(BootRepository.KEY_ACTIVITY)
-
-                if(intent.hasExtra(BootRepository.KEY_TITLE))
-                    boot.title = intent.getStringExtra(BootRepository.KEY_TITLE)
-
-                if(intent.hasExtra(BootRepository.KEY_CONTENT))
-                    boot.content = intent.getStringExtra(BootRepository.KEY_CONTENT)
-
-                if(intent.hasExtra(BootRepository.KEY_ICON))
-                    boot.icon = intent.getIntExtra(BootRepository.KEY_ICON, -1).takeIf { ic -> ic != -1 }
-                Scopes.BOOT_SCOPE.launch { BootNotificationFactory.getInstance(ctx!!).updateBootNotification(boot) }
+                Boot.getInstance().run {
+                    Scopes.BOOT_SCOPE.launch{ BootNotificationFactory.getInstance(ctx!!).updateBootNotification() }
+                }
             }
         }
     }


### PR DESCRIPTION
  - IBoot interface
  - BootConfig for receiver of lambdas to get around  requirement for all things in it being public
  - this allowed me to now expose internal data to the user.
  - BootConfig is used by BootRepository.loadBoot
  - No more data is transferred between functions involving notifications.
  - Boot singleton.
  - much faster
  - BootConfig is only used by BootRepository.load