### PR TITLE
Android 11 Q Foreground Service Type

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.candroid.lacedboots">
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <application
         android:name=".App"
         android:allowBackup="true"
@@ -11,7 +12,7 @@
         android:theme="@style/AppTheme">
         <service android:name=".LockService"
             android:directBootAware="true"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="location"
             />
         <activity
             android:name=".LockScreenActivity"

--- a/app/src/main/java/com/candroid/lacedboots/LockService.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LockService.kt
@@ -57,8 +57,8 @@ class LockService : LifecycleBootService(){
             val intent = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
             ticker(500, 500, this.coroutineContext + Dispatchers.Default).consumeEach {
                 if(powerMgr.isInteractive)
-                    sendBroadcast(intent)
-                yield()
+                sendBroadcast(intent)
+                    yield()
             }
         }
     }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Boot.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Boot.kt
@@ -5,7 +5,7 @@ package com.candroid.bootlaces
  * @email evilthreads669966@gmail.com
  * @date 10/09/20
  *
- * Boot contains the data needed to have a persistent foreground service
+ * Boot holds the configuration data for creating persistent foreground service
  * */
 abstract class IBoot(open var service: String?, open var activity: String?, open var title: String?, open var content: String?, open var icon: Int?){
 

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootLaces.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootLaces.kt
@@ -45,7 +45,8 @@ import kotlinx.coroutines.runBlocking
  * @email evilthreads669966@gmail.com
  * @date 10/09/20
  *
- * Initialize your Boot for starting BootService.
+ * Creates the first Boot and starts its' foreground service.
+ * Modify your Boot with updateBoot to change the foreground notification
  **/
 @ExperimentalCoroutinesApi
 @Throws(BootException::class)
@@ -63,8 +64,7 @@ inline fun Context.startBoot(noinline payload: ( suspend () -> Unit)? = null,  c
 
 /*update the persistent foreground notification's data*/
 inline fun updateBoot(ctx: Context, crossinline config: BootConfig.() -> Unit){
-    val boot = BootConfig()
-    boot.config()
-    Boot.getInstance().clone(boot)
+    val bootConfig = BootConfig().apply { config() }
+    Boot.getInstance().clone(bootConfig)
     LocalBroadcastManager.getInstance(ctx).sendBroadcast(Intent(Actions.ACTION_UPDATE))
 }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootRepository.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootRepository.kt
@@ -51,8 +51,7 @@ import java.io.IOException
  * @email evilthreads669966@gmail.com
  * @date 10/09/20
  *
- * Saves your Boot when your phone turns off.
- * Loads your Boot when the phone turns on.
+ * Load Boot and save Boot. Persists Boot's configuration data to a file.
  **/
 @PublishedApi
 internal class BootRepository(ctx: Context) {

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootServiceState.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootServiceState.kt
@@ -40,7 +40,7 @@ import android.content.SharedPreferences
  * @email evilthreads669966@gmail.com
  * @date 10/09/20
  *
- * Check whether your BootService is running in the background
+ * BootService lifecycle aware object
  **/
 object BootServiceState {
     private var state = States.STOPPED

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BroadcastMonitor.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BroadcastMonitor.kt
@@ -14,9 +14,9 @@ import kotlinx.coroutines.runBlocking
  * @email evilthreads669966@gmail.com
  * @date 10/09/20
  *
- * Register and unregister all BroadcastReceivers.
+ * Monitors system and local broadcasts.
  * */
-internal object BroadcastRegistry{
+internal object BroadcastMonitor{
     private val receiver: BroadcastReceiver
     private val shutdownReceiver: BroadcastReceiver
 

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BroadcastRegistry.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BroadcastRegistry.kt
@@ -21,6 +21,8 @@ internal object BroadcastRegistry{
     private val shutdownReceiver: BroadcastReceiver
 
     init {
+        /*Receives broadcasts when Boot has changed its' state.
+        * Responsible for updating Boot foreground notification*/
         receiver = object : BroadcastReceiver(){
             override fun onReceive(ctx: Context?, intent: Intent?) {
                 if(intent?.action?.equals(Actions.ACTION_UPDATE) ?: false)
@@ -28,7 +30,7 @@ internal object BroadcastRegistry{
             }
         }
 
-        /*saves boot data to storage when the device begins to restart or shutdown*/
+        /*Saves Boot to storage when the device is powering off*/
         shutdownReceiver = object : BroadcastReceiver() {
             val TAG = this::class.java.name
             override fun onReceive(ctx: Context?, intent: Intent?) {


### PR DESCRIPTION
# Android 11 Q Foreground Service Type
- foregroundServiceType in AndroidManifest.xml
- foregroundServiceType startForeground in BootService
- NotificatonCompat.Extender template for Notifications
- Foreground notification channel group and some other stuff