### PR TITLE
Structured Concurrency using Reactive Streams

### DIFF
--- a/app/src/main/java/com/candroid/lacedboots/LockScreenActivity.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LockScreenActivity.kt
@@ -58,6 +58,7 @@ class LockScreenActivity: VisibilityActivity(){
                 scheduler.run {
                     schedulePersistent(ScreenLockerJob())
                     scheduleOneTime(OneTimeWorker())
+                    scheduleOneTime(SecondWorker())
                 }
             }
         }

--- a/app/src/main/java/com/candroid/lacedboots/Workers.kt
+++ b/app/src/main/java/com/candroid/lacedboots/Workers.kt
@@ -57,6 +57,15 @@ class OneTimeWorker: Worker(66,"One time work") {
             delay(1000)
     }
 }
+class SecondWorker: Worker(99,"Second worker") {
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        for(i in 1..10)
+            delay(1000)
+    }
+}
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @ObsoleteCoroutinesApi


### PR DESCRIPTION
- consume channel as flow
- replace launch builders with launchln collector