### PR TITLE
Remove Dispatcher from handleWorker launch 

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -132,7 +132,7 @@ abstract class WorkService: LifecycleService() {
         }
         if(!BootServiceState.isForeground())
             foreground.activate()
-        coroutineScope.launch(Dispatchers.Default){
+        coroutineScope.launch{
             val intent = IntentFactory.createWorkNotificationIntent(worker)
             NotificatonService.enqueue(this@WorkService, intent)
             worker.doWork(this@WorkService)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Worker.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Worker.kt
@@ -72,4 +72,3 @@ abstract class Worker(val id: Int, val description: String){
           }
      }
 }
-


### PR DESCRIPTION
- use preexisting dispatcher element from coroutine scope in handleWorker's launch coroutine builder