### PR TITLE
Delete Future Worker From Database

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -102,7 +102,10 @@ class WorkService: BaseWorkService() {
                     Actions.ACTION_WORK_PERSISTENT.action -> { withContext(Dispatchers.IO){ foreground.database.insert(work) } }
                     Actions.ACTION_WORK_ONE_TIME.action -> { withContext(Dispatchers.Default){ foreground.channel.send(work) } }
                     Actions.ACTION_WORK_PERIODIC.action -> { withContext(Dispatchers.Default){ foreground.channel.send(work) } }
-                    Actions.ACTION_WORK_FUTURE.action -> { withContext(Dispatchers.Default){ foreground.channel.send(work) } }
+                    Actions.ACTION_WORK_FUTURE.action -> {
+                        withContext(Dispatchers.Default){ foreground.channel.send(work) }
+                        withContext(Dispatchers.IO){ foreground.database.delete(work) }
+                    }
                     else -> return@launch
                 }
             }


### PR DESCRIPTION
- delete future worker from work table in database after it runs to prevent it from running again after device reboots