### PR TITLE
LauncherActivity extends AppCompatActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         android:theme="@style/AppTheme">
 
         <activity android:name=".LauncherActivity"
-            android:launchMode="singleInstance"
             android:resizeableActivity="false"
             android:screenOrientation="portrait">
             <intent-filter>

--- a/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
@@ -19,6 +19,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.candroid.bootlaces.WorkScheduler
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,7 +51,7 @@ import javax.inject.Inject
 @ExperimentalCoroutinesApi
 @ObsoleteCoroutinesApi
 @AndroidEntryPoint
-class LauncherActivity: VisibilityActivity(){
+class LauncherActivity: AppCompatActivity(){
     companion object{
         private const val mOverlay_request_code = 666
     }


### PR DESCRIPTION
- LauncherActivity.kt extends AppCompatActivity instead of VisibilityActivity
- remove singleInstance launch mode from LauncherActivity.kt declaration in manifest.xml