### PR TITLE
Supervisor for Cancellation

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/Hilt.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Hilt.kt
@@ -81,7 +81,8 @@ interface ForegroundEntryPoint{
 object BackgroundModule{
     @Provides fun provideChannel() = Channel<Work>()
     @Provides fun provideAlarmManager(@ApplicationContext ctx: Context) = ctx.getSystemService(LifecycleService.ALARM_SERVICE) as AlarmManager
-    @Provides fun provideScope() = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    @Provides fun provideScope() = CoroutineScope(Dispatchers.Default + provideSupervisor())
+    @Provides fun provideSupervisor(): CompletableJob = SupervisorJob()
 }
 
 @InstallIn(ServiceComponent::class)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -67,6 +67,7 @@ class WorkService(): Service() {
     @Inject lateinit var database: WorkDao
     @Inject lateinit var channel: Channel<Work>
     @Inject lateinit var scope: CoroutineScope
+    @Inject lateinit var supervisor: CompletableJob
 
     private lateinit var foreground: ForegroundActivator
     private val workers = Collections.synchronizedSet(mutableSetOf<Worker>())
@@ -112,7 +113,7 @@ class WorkService(): Service() {
     }
 
     override fun onDestroy() {
-        scope.also { it.coroutineContext.cancelChildren() }.cancel()
+        supervisor.also { it.cancelChildren() }.cancel()
         channel.close()
         workers.forEach { it.unregisterWorkReceiver() }
         workers.clear()


### PR DESCRIPTION
- inject SupervisorJob in WorkService.kt
  - use supervisor for cancelling child jobs instead of scope