### PR TITLE
WakeScope

### DIFF
--- a/bootlaces/build.gradle
+++ b/bootlaces/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     kaptTest "com.google.dagger:hilt-android-compiler:$hilt_version"
     testImplementation "org.robolectric:robolectric:4.4"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    implementation 'com.github.evilthreads669966:wakescope:2.0'
     //kaptAndroidTest "androidx.hilt:hilt-compiler:$hilt_version"
 /*
     implementation "androidx.lifecycle:lifecycle-extensions:$archLifecycleVersion"

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.SystemClock
 import androidx.core.app.ServiceCompat
+import com.evilthreads.wakescopelib.wakeScope
 import dagger.hilt.EntryPoints
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
@@ -87,7 +88,7 @@ class WorkService(): Service() {
         state = ServiceState.BACKGROUND
         foreground = EntryPoints.get(provider.get().build(),ForegroundEntryPoint::class.java).getActivator()
         scope = CoroutineScope(Dispatchers.Default + supervisor)
-        scope.launch { handleWork() }
+        wakeScope { scope.launch { handleWork() } }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {


### PR DESCRIPTION
- add wakescope library
  - wrap handleWork inside wakeScope to keep processor alive while WorkService.kt is running