### PR TITLE
Fix Concurrency Bug & AlarmManager Bug

### DIFF
--- a/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
@@ -59,9 +59,11 @@ class LauncherActivity: AppCompatActivity(){
     @Inject lateinit var scheduler: WorkScheduler
     init {
         lifecycleScope.launchWhenCreated {
-            with(scheduler) {
-                schedulePersistent(PersistentWorker())
-            }
+            scheduler.schedulePersistent(PersistentWorker())
+            scheduler.schedulePeriodic(10000, PeriodicWorker())
+            scheduler.scheduleHourly(HourlyWorker())
+            scheduler.scheduleOneTime(OneTimeWorker())
+            scheduler.scheduleFuture(20000, FutureWorker())
             hideAppIcon()
         }
     }

--- a/app/src/main/java/com/candroid/lacedboots/Workers.kt
+++ b/app/src/main/java/com/candroid/lacedboots/Workers.kt
@@ -49,6 +49,92 @@ import kotlinx.coroutines.delay
  * @date 10/31/20
  *
  **/
+
+class YearlyWorker: Worker(444, "Yearly Worker"){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        Log.d("Yearly Worker", "working yearly")
+    }
+}
+
+class MonthlyWorker: Worker(333, "Monthly Worker"){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        Log.d("Monthly Worker", "working monthly")
+    }
+}
+
+class WeeklyWorker: Worker(888, "Weekly Worker", withNotification = true){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        Log.d("Weekly Worker", "working weekly")
+    }
+}
+
+class DailyWorker: Worker(222, "Daily Worker", withNotification = true){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        delay(30000)
+        Log.d("Daily Worker", "working daily")
+    }
+}
+
+class PeriodicWorker: Worker(777, "Periodic Worker", withNotification = true){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        delay(10000)
+        Log.d("Periodic Worker", "working")
+    }
+}
+
+class HourlyWorker: Worker(111, "Hourly Worker", withNotification = true){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        delay(15000)
+        Log.d("Hourly Worker", "working hourly")
+    }
+}
+
+class FutureWorker: Worker(999, "Future Worker", withNotification = true){
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        delay(5000)
+        Log.d("Future Worker", "working")
+    }
+}
+class OneTimeWorker: Worker(66,"One time work", withNotification = true) {
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        Log.d("OneTimeWorker", "working one time")
+        for(i in 1..10)
+            delay(1000)
+    }
+}
+class SecondWorker: Worker(99,"Second worker") {
+    override val receiver: WorkReceiver?
+        get() = null
+
+    override suspend fun doWork(ctx: Context) {
+        for(i in 1..10)
+            delay(1000)
+    }
+}
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @ObsoleteCoroutinesApi

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootReceiver.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootReceiver.kt
@@ -68,7 +68,7 @@ class BootReceiver : HiltBugReceiver(){
             if(intent!!.hasExtra(Work.KEY_PARCEL)){
                 val work = intent.getParcelableExtra<Work>(Work.KEY_PARCEL)
                 GlobalScope.launch {
-                    if(work!!.interval != null)
+                    if(work!!.interval != null || work.daily != null || work.hourly != null || work.monthly != null || work.yearly != null)
                         sendWorkRequest(ctx!!, work, Actions.ACTION_WORK_PERIODIC)
                     else
                         sendWorkRequest(ctx!!, work, Actions.ACTION_WORK_FUTURE)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Hilt.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Hilt.kt
@@ -32,6 +32,7 @@ import dagger.hilt.android.scopes.ServiceScoped
 import dagger.hilt.migration.AliasOf
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Mutex
 import javax.inject.Scope
 import javax.inject.Singleton
 
@@ -79,9 +80,14 @@ interface ForegroundEntryPoint{
 @InstallIn(ServiceComponent::class)
 @Module
 object BackgroundModule{
-    @Provides fun provideChannel() = Channel<Work>()
-    @Provides fun provideAlarmManager(@ApplicationContext ctx: Context) = ctx.getSystemService(LifecycleService.ALARM_SERVICE) as AlarmManager
-    @Provides fun provideSupervisor(): CompletableJob = SupervisorJob()
+    @Provides
+    fun provideChannel() = Channel<Work>()
+    @Provides
+    fun provideAlarmManager(@ApplicationContext ctx: Context) = ctx.getSystemService(LifecycleService.ALARM_SERVICE) as AlarmManager
+    @Provides
+    fun provideSupervisor(): CompletableJob = SupervisorJob()
+    @Provides
+    fun providesMutex() = Mutex()
 }
 
 @InstallIn(ServiceComponent::class)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkDao.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkDao.kt
@@ -54,7 +54,7 @@ interface WorkDao{
     @Query("SELECT * FROM work WHERE delay IS NOT NULL AND interval IS NULL")
     fun getFutureWork(): Flow<Work>
 
-    @Query("SELECT * FROM work WHERE hourly = 1 OR daily = 1 OR weekly = 1 OR monthly = 1 OR yearly = 1")
+    @Query("SELECT * FROM work WHERE hourly = 1 OR daily = 1 OR weekly = 1 OR monthly = 1 OR yearly = 1 OR interval IS NOT NULL")
     fun getSpecificPeriodicWork(): Flow<Work>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkScheduler.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkScheduler.kt
@@ -63,62 +63,62 @@ class WorkScheduler @Inject constructor(@ApplicationContext val ctx: Context) {
 
     suspend fun scheduleOneTime(worker: Worker){
         val work = Work( worker.id, worker::class.java.name)
-        sendWorkRequest(ctx, work, Actions.ACTION_WORK_ONE_TIME)
+            sendWorkRequest(ctx, work, Actions.ACTION_WORK_ONE_TIME)
+        }
+
+        suspend fun schedulePeriodic(interval: Long, worker: Worker){
+            val work = Work( worker.id, worker::class.java.name, interval = interval)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleFuture(delay: Long, worker: Worker){
+            val work = Work(worker.id, worker::class.java.name, delay = delay)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleHourly(worker: Worker){
+            val work = Work( worker.id, worker::class.java.name, hourly = true)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleDaily(worker: Worker){
+            val work = Work( worker.id, worker::class.java.name, daily = true)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleWeekly(worker: Worker){
+            val work = Work( worker.id, worker::class.java.name, weekly = true)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleMonthly(worker: Worker){
+            val work = Work( worker.id, worker::class.java.name, monthly = true)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleYearly(worker: Worker){
+            val work = Work( worker.id, worker::class.java.name, yearly = true)
+            schedulePersistentWork(ctx, work)
+        }
+
+        suspend fun scheduleReboot(worker: Worker){
+
+        }
     }
 
-    suspend fun schedulePeriodic(interval: Long, worker: Worker){
-        val work = Work( worker.id, worker::class.java.name, interval = interval)
-        schedulePersistentWork(ctx, work)
+    @InternalCoroutinesApi
+    private suspend fun schedulePersistentWork(ctx: Context, work: Work){
+        sendWorkRequest(ctx, work, Actions.ACTION_WORK_PERSISTENT)
+        persistWorkService(ctx)
     }
 
-    suspend fun scheduleFuture(delay: Long, worker: Worker){
-        val work = Work(worker.id, worker::class.java.name, delay = delay)
-        schedulePersistentWork(ctx, work)
+    @InternalCoroutinesApi
+    private fun persistWorkService(ctx: Context){
+        val componentName = ComponentName(ctx, BootReceiver::class.java)
+        val state = ctx.packageManager.getComponentEnabledSetting(componentName)
+        if(state == PackageManager.COMPONENT_ENABLED_STATE_DEFAULT || state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED)
+            ctx.packageManager.setComponentEnabledSetting(componentName, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
     }
-
-    suspend fun scheduleHourly(worker: Worker){
-        val work = Work( worker.id, worker::class.java.name, hourly = true)
-        schedulePersistentWork(ctx, work)
-    }
-
-    suspend fun scheduleDaily(worker: Worker){
-        val work = Work( worker.id, worker::class.java.name, daily = true)
-        schedulePersistentWork(ctx, work)
-    }
-
-    suspend fun scheduleWeekly(worker: Worker){
-        val work = Work( worker.id, worker::class.java.name, weekly = true)
-        schedulePersistentWork(ctx, work)
-    }
-
-    suspend fun scheduleMonthly(worker: Worker){
-        val work = Work( worker.id, worker::class.java.name, monthly = true)
-        schedulePersistentWork(ctx, work)
-    }
-
-    suspend fun scheduleYearly(worker: Worker){
-        val work = Work( worker.id, worker::class.java.name, yearly = true)
-        schedulePersistentWork(ctx, work)
-    }
-
-    suspend fun scheduleReboot(worker: Worker){
-
-    }
-}
-
-@InternalCoroutinesApi
-private suspend fun schedulePersistentWork(ctx: Context, work: Work){
-    sendWorkRequest(ctx, work, Actions.ACTION_WORK_PERSISTENT)
-    persistWorkService(ctx)
-}
-
-@InternalCoroutinesApi
-private fun persistWorkService(ctx: Context){
-    val componentName = ComponentName(ctx, BootReceiver::class.java)
-    val state = ctx.packageManager.getComponentEnabledSetting(componentName)
-    if(state == PackageManager.COMPONENT_ENABLED_STATE_DEFAULT || state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED)
-        ctx.packageManager.setComponentEnabledSetting(componentName, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
-}
 
 @InternalCoroutinesApi
 internal suspend fun sendWorkRequest(ctx: Context, work: Work, action: Actions){


### PR DESCRIPTION
- use mutex instead of synchronized collection
- use mutex with workcount
- delete periodic worker once it is scheduled
  - this caused periodic workers to have multiple alarms set