### PR TITLE
Remove Launch Builders in handleWork

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -149,8 +149,8 @@ class WorkService: Service(), ComponentCallbacks2,IWorkHandler<Worker, Flow<Work
 
     override suspend fun CoroutineScope.handleWork(){
         val ioScope = CoroutineScope(this.coroutineContext + Dispatchers.IO)
-        this.launch { database.getPersistentWork().filterNotNull().processWork(ioScope) }
-        this.launch { channel.consumeAsFlow().processWork(scope) }
+        database.getPersistentWork().filterNotNull().processWork(ioScope)
+        channel.consumeAsFlow().processWork(scope)
     }
 
     private fun Worker.unregisterWorkReceiver() = this.receiver?.let { unregisterReceiver(it) }


### PR DESCRIPTION
- remove coroutine launch builders from handleWork in WorkService.kt
  - not needed
  - I added them back in when I was debugging after a redesign