### PR TITLE
Fix Persistent Work Query Bug

### DIFF
--- a/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
@@ -71,6 +71,7 @@ class LauncherActivity: AppCompatActivity(){
             WorkerSeven().scheduleNow()
             WorkerEight().scheduleHoursTwo(true)
             WorkerTen().scheduleHalfWeek(false)
+            WorkerFourteen().schedulePersistent()
         }
     }
 }

--- a/app/src/main/java/com/candroid/lacedboots/Workers.kt
+++ b/app/src/main/java/com/candroid/lacedboots/Workers.kt
@@ -16,12 +16,10 @@ package com.candroid.lacedboots
 import android.app.AlarmManager
 import android.content.Context
 import android.content.Intent
+import android.icu.util.Calendar
 import android.os.PowerManager
 import android.util.Log
 import com.candroid.bootlaces.Worker
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.delay
 
 /*
@@ -137,7 +135,7 @@ class WorkerSix: Worker(6, "Worker Six", true){
 
 class WorkerSeven: Worker(7, "Worker Seven", true){
     val tag = this::class.java.name
-    
+
     override val receiver: WorkReceiver?
         get() = null
 
@@ -215,8 +213,29 @@ class WorkerNine: Worker(9,"Worker Nine", true){
         while(true){
             Log.d(tag, "Working for 25 seconds")
             delay(25000)
-    /*        if (powerMgr.isInteractive)
-                ctx.sendBroadcast(intent)*/
+            /*        if (powerMgr.isInteractive)
+                        ctx.sendBroadcast(intent)*/
+        }
+    }
+}
+
+class WorkerFourteen: Worker(14,"Worker Fourteen", true){
+    val tag = this::class.java.name
+
+    override val receiver: WorkReceiver?
+        get() = object : WorkReceiver(Intent.ACTION_TIME_TICK) {
+            val tag = this::class.java.name
+            val calendar = Calendar.getInstance()
+            override fun onReceive(ctx: Context?, intent: Intent?) {
+                if(intent?.action?.equals(Intent.ACTION_TIME_TICK) ?: false)
+                    Log.d(tag, "second of day: ${calendar.get(Calendar.SECOND)}")
+            }
+        }
+
+    override suspend fun doWork(ctx: Context) {
+        while(true){
+            Log.d(tag, "working for three minutes")
+            delay(60000L * 3)
         }
     }
 }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Actions.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Actions.kt
@@ -39,7 +39,7 @@ package com.candroid.bootlaces
  *
  * local actions
  **/
-enum class Actions(val action: String){
+internal enum class Actions(val action: String){
     ACTION_START("ACTION_START"),
     ACTION_FINISH("ACTION_FINISH"),
     ACTION_WORK_PERSISTENT("ACTION_WORK_PERSISTENT"),

--- a/bootlaces/src/main/java/com/candroid/bootlaces/BootReceiver.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/BootReceiver.kt
@@ -59,11 +59,11 @@ class BootReceiver : HiltBugReceiver(){
     override fun onReceive(ctx: Context?, intent: Intent?){
         super.onReceive(ctx, intent)
         if(!WorkService.isStarted() && intent?.action?.contains("BOOT") ?: false) {
-            intent?.setClass(ctx!!, WorkService::class.java)
+            intent?.setClass(ctx ?: return, WorkService::class.java)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                ctx!!.startForegroundService(intent)
+                ctx?.startForegroundService(intent)
             else
-                ctx!!.startService(intent)
+                ctx?.startService(intent)
         }
     }
 }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/ForegroundActivator.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/ForegroundActivator.kt
@@ -53,7 +53,7 @@ import javax.inject.Inject
  **/
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
-class ForegroundActivator @Inject constructor(val ctx: Service){
+internal class ForegroundActivator @Inject constructor(val ctx: Service){
      @Inject lateinit var factory: NotificationFactory
      private fun notifyForeground() {
           val notification = factory.createForegroundNotification()

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Hilt.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Hilt.kt
@@ -30,7 +30,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
-import javax.inject.Singleton
 
 /*
             (   (                ) (             (     (
@@ -63,10 +62,9 @@ import javax.inject.Singleton
 @InternalCoroutinesApi
 @Module
 @InstallIn(ApplicationComponent::class)
-object BroadcastReceiverModule {
-    @Singleton
-    @Provides fun provideWorkDao(@ApplicationContext ctx: Context): WorkDao = Room.databaseBuilder(ctx, WorkDatabase::class.java, "worker_database").build().workerDao()
-    @Singleton
+internal object GlobalModule {
+    @Provides
+    fun provideWorkDao(@ApplicationContext ctx: Context): WorkDao = Room.databaseBuilder(ctx, WorkDatabase::class.java, "worker_database").build().workerDao()
     @Provides
     fun provideAlarmMgr(@ApplicationContext ctx: Context) = ctx.getSystemService(Service.ALARM_SERVICE) as AlarmManager
 }
@@ -75,14 +73,14 @@ object BroadcastReceiverModule {
 @InternalCoroutinesApi
 @EntryPoint
 @InstallIn(ForegroundComponent::class)
-interface ForegroundEntryPoint{
+internal interface ForegroundEntryPoint{
     @ExperimentalCoroutinesApi
     fun getForeground(): ForegroundActivator
 }
 
 @InstallIn(ServiceComponent::class)
 @Module
-object BackgroundModule{
+internal object BackgroundModule{
     @Provides
     fun provideChannel() = Channel<Work>()
     @Provides
@@ -95,13 +93,15 @@ object BackgroundModule{
 
 @InstallIn(ServiceComponent::class)
 @Module
-object ForegroundModule{
-    @Provides fun provideNotificationBuilder(@ApplicationContext ctx: Context) = NotificationCompat.Builder(ctx)
-    @Provides fun provideNotificationMgr(@ApplicationContext ctx: Context) = NotificationManagerCompat.from(ctx)
+internal object ForegroundModule{
+    @Provides
+    fun provideNotificationBuilder(@ApplicationContext ctx: Context) = NotificationCompat.Builder(ctx)
+    @Provides
+    fun provideNotificationMgr(@ApplicationContext ctx: Context) = NotificationManagerCompat.from(ctx)
 }
 
 @DefineComponent(parent = ServiceComponent::class)
-interface ForegroundComponent{
+internal interface ForegroundComponent{
     @DefineComponent.Builder
     interface Builder {
         fun build(): ForegroundComponent

--- a/bootlaces/src/main/java/com/candroid/bootlaces/NotificationFactory.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/NotificationFactory.kt
@@ -60,7 +60,7 @@ import javax.inject.Singleton
  * @date 10/31/20
  * creates notifications for foreground and workers
  **/
-class NotificationFactory @Inject constructor(@ApplicationContext val ctx: Context, val mgr: NotificationManagerCompat, val builder: NotificationCompat.Builder){
+internal class NotificationFactory @Inject constructor(@ApplicationContext val ctx: Context, val mgr: NotificationManagerCompat, val builder: NotificationCompat.Builder){
     internal fun createStartedNotification(description: String?): Notification{
         createBackgroundChannel(ctx, mgr)
         return builder.apply {

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkDao.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkDao.kt
@@ -43,9 +43,9 @@ import kotlinx.coroutines.flow.Flow
  *
  **/
 @Dao
-interface WorkDao{
+internal interface WorkDao{
     @Query("SELECT * FROM work")
-    fun getPersistentWork(): Flow<Work>
+    fun getPersistentWork(): Flow<List<Work>>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(worker: Work)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkDatabase.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkDatabase.kt
@@ -43,6 +43,6 @@ import androidx.room.RoomDatabase
  *
  **/
 @Database(entities = arrayOf(Work::class), version = 1, exportSchema = false)
-abstract class WorkDatabase: RoomDatabase(){
+internal abstract class WorkDatabase: RoomDatabase(){
     abstract fun workerDao(): WorkDao
 }


### PR DESCRIPTION
- change return type of getPersistentWork from Flow<Work> to Flow<List<Work>>
- non persistent work channel doesn't use processWork ktx anymore due to receiver type
- mark classes, properties, and functions internal or private where possible
- add second persistent worker with WorkReceiver for testing WorkerFourteen