### PR TITLE
Private Member Variables

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/ForegroundActivator.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/ForegroundActivator.kt
@@ -53,8 +53,8 @@ import javax.inject.Inject
  **/
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
-internal class ForegroundActivator @Inject constructor(val ctx: Service){
-     @Inject lateinit var factory: NotificationFactory
+internal class ForegroundActivator @Inject constructor(private val ctx: Service){
+     @Inject internal lateinit var factory: NotificationFactory
      private fun notifyForeground() {
           val notification = factory.createForegroundNotification()
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/bootlaces/src/main/java/com/candroid/bootlaces/IntentFactory.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/IntentFactory.kt
@@ -55,7 +55,7 @@ import javax.inject.Singleton
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
 @Singleton
-class IntentFactory @Inject constructor(@ApplicationContext val ctx: Context){
+class IntentFactory @Inject constructor(@ApplicationContext private val ctx: Context){
 
     internal fun createWorkNotificationIntent(worker: Worker): Intent = Intent().apply {
         setAction(Actions.ACTION_START.action)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/NotificationFactory.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/NotificationFactory.kt
@@ -60,7 +60,7 @@ import javax.inject.Singleton
  * @date 10/31/20
  * creates notifications for foreground and workers
  **/
-internal class NotificationFactory @Inject constructor(@ApplicationContext val ctx: Context, val mgr: NotificationManagerCompat, val builder: NotificationCompat.Builder){
+internal class NotificationFactory @Inject constructor(@ApplicationContext private val ctx: Context, internal val mgr: NotificationManagerCompat, private val builder: NotificationCompat.Builder){
     internal fun createStartedNotification(description: String?): Notification{
         createBackgroundChannel(ctx, mgr)
         return builder.apply {

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkScheduler.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkScheduler.kt
@@ -53,7 +53,7 @@ import javax.inject.Singleton
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
 @Singleton
-class WorkScheduler @Inject constructor(@ApplicationContext val ctx: Context, val alarmMgr: AlarmManager, val factory: IntentFactory) {
+class WorkScheduler @Inject constructor(@ApplicationContext private val ctx: Context,private val alarmMgr: AlarmManager, private val factory: IntentFactory) {
     /*use this scoping function to schedule workers
     * ie: scheduler.use { MyWorker().scheduleHour() }
     * */


### PR DESCRIPTION
- mark member variables private in classes if not needed outside of their context