### PR TITLE
START_STICKY

### DIFF
--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -100,7 +100,7 @@ class WorkService: Service(), ComponentCallbacks2 {
         workCoroutineScope.launch { startAction(intent) }
         super.onStartCommand(intent, flags, startId)
         this.startId = startId
-        return START_NOT_STICKY
+        return START_STICKY
     }
 
     private suspend fun startAction(intent: Intent?){


### PR DESCRIPTION
- change onStartCommand return flag
  - from not sticky to sticky
    - i don't know why i changed it back again I read it and clearly needs to be start_sticky	