### PR TITLE
Multiple Actions For WorkReceiver

### DIFF
--- a/app/src/main/java/com/candroid/lacedboots/Workers.kt
+++ b/app/src/main/java/com/candroid/lacedboots/Workers.kt
@@ -159,11 +159,19 @@ class WorkerFourteen: Worker(14, "survives reboot and performs every hour", true
 
    class ReceiverAtReboot: PersistentReceiver(18){
        override val receiver: WorkReceiver?
-           get() = object : WorkReceiver(Intent.ACTION_BATTERY_LOW){
+           get() = object : WorkReceiver(Intent.ACTION_AIRPLANE_MODE_CHANGED, Intent.ACTION_BATTERY_CHANGED){
                override fun onReceive(ctx: Context?, intent: Intent?) {
                    super.onReceive(ctx, intent)
-                   if(intent?.action.equals(this.action))
-                       Log.d(this@ReceiverAtReboot.tag, "battery is low")
+                   goAsync().apply {
+                       if(intent?.action.equals(Intent.ACTION_BATTERY_CHANGED))
+                           Log.d(this@ReceiverAtReboot.tag, "battery level changed")
+                       else if(intent?.action.equals(Intent.ACTION_AIRPLANE_MODE_CHANGED))
+                           Log.d(this@ReceiverAtReboot.tag, "airplane mode changed")
+                       else
+                           Log.d(this@ReceiverAtReboot.tag, "action not found")
+                   }.finish()
+
+
                }
            }
    }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Worker.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Worker.kt
@@ -50,46 +50,44 @@ import kotlin.coroutines.CoroutineContext
  * @email evilthreads669966@gmail.com
  * @date 10/18/20
  **/
-abstract class Worker(val id: Int, val description: String, val withNotification: Boolean, dispatcher: CoroutineDispatcher = Dispatchers.Default): CoroutineWorker(dispatcher){
+abstract class Worker(val id: Int, val description: String, val withNotification: Boolean, dispatcher: CoroutineDispatcher = Dispatchers.Default): CoroutineWorker(dispatcher) {
      val tag = this::class.java.name
 
      internal companion object {
-          fun createFromWork(work: Work): Worker = Class.forName(work.workerName).newInstance() as Worker
+          fun createFromWork(work: Work): Worker =
+               Class.forName(work.workerName).newInstance() as Worker
      }
+
      open val receiver: WorkReceiver? = null
 
      suspend abstract fun doWork(ctx: Context)
 
      override fun equals(other: Any?): Boolean {
-          if(this === other) return true
-          if(other !is Worker) return false
-          if(this.id == other.id && this.description.equals(other.description))
+          if (this === other) return true
+          if (other !is Worker) return false
+          if (this.id == other.id && this.description.equals(other.description))
                return true
           return false
      }
 
      override fun hashCode(): Int = id.hashCode()
 
-     open class WorkReceiver(val action: String): BroadcastReceiver(){
+     open class WorkReceiver(vararg val action: String) : BroadcastReceiver() {
           val tag = this::class.java.name
 
-          override fun onReceive(ctx: Context?, intent: Intent?){}
+          override fun onReceive(ctx: Context?, intent: Intent?) {}
 
           override fun hashCode() = action.hashCode()
 
           override fun equals(other: Any?): Boolean {
-               if(this === other) return true
-               if(other !is WorkReceiver) return false
-               if(this.action.equals(other.action)) return true
+               if (this === other) return true
+               if (other !is WorkReceiver) return false
+               if (this.action.contentEquals(other.action)) return true
                return false
           }
      }
 
      internal fun hasReceiver(): Boolean = receiver != null
-
-     internal fun unregisterReceiver(ctx: Context): Boolean = receiver?.apply { ctx.unregisterReceiver(this) } != null
-
-     internal fun registerReceiver(ctx: Context): Boolean = receiver?.apply { ctx.registerReceiver(this, IntentFilter(action)) } != null
 }
 
 sealed class CoroutineWorker(dispatcher: CoroutineDispatcher): CoroutineScope{


### PR DESCRIPTION
- change Worker.WorkReceiver action field from val to vararg val
- delete unregisterReceiver & registerReceiver in Worker
- add registerWorkReceiver function to WorkService
  - change logic from previous function to handle vararg action
- add a second action to ReceiverAtReboot for demo app
  - Intent.ACTION_AIRPLANE_MODE_CHANGED 