### PR TITLE
Move Rescheduling to BOOT_COMPLETE BroadcastReceiver

### DIFF
--- a/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
+++ b/app/src/main/java/com/candroid/lacedboots/LauncherActivity.kt
@@ -15,6 +15,7 @@ package com.candroid.lacedboots
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.candroid.bootlaces.IntentFactory
 import com.candroid.bootlaces.WorkScheduler
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.runBlocking

--- a/bootlaces/src/main/AndroidManifest.xml
+++ b/bootlaces/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false"
             android:enabled="true" />
-        <receiver android:name=".BootReceiver" android:enabled="false" android:exported="true" android:directBootAware="true" android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
+        <receiver android:name=".ReschedulingReceiver" android:enabled="false" android:exported="true" android:directBootAware="true" android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
             <intent-filter android:priority="999">
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED"/>

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Actions.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Actions.kt
@@ -42,7 +42,6 @@ package com.candroid.bootlaces
 internal enum class Actions(internal val action: String){
     ACTION_START("ACTION_START"),
     ACTION_FINISH("ACTION_FINISH"),
-    ACTION_RESCHEDULE("ACTION_RESCHEDULE"),
     ACTION_EXECUTE_WORKER("ACTION_EXPIRED_WORK"),
     ACTION_WORK_CANCEL("ACTION_WORK_CANCEL"),
 }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/IntentFactory.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/IntentFactory.kt
@@ -55,11 +55,6 @@ import javax.inject.Singleton
 @Singleton
 class IntentFactory @Inject internal constructor(@ApplicationContext private val ctx: Context){
 
-    fun createRescheduleIntent() = Intent().apply{
-        setAction(Actions.ACTION_RESCHEDULE.action)
-        setClass(ctx, WorkService::class.java)
-    }
-
     fun createWorkNotificationIntent(worker: Worker) = Intent().apply {
         setAction(Actions.ACTION_START.action)
         putExtra(NotificatonService.KEY_ID, worker.id)

--- a/bootlaces/src/main/java/com/candroid/bootlaces/Utils.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/Utils.kt
@@ -46,6 +46,6 @@ private fun Class<*>.enableComponent(ctx: Context): Boolean{
 }
 
 internal object Utils{
-    fun isRebootEnabled(ctx: Context) = BootReceiver::class.java.isComponentEnabled(ctx)
-    fun enableReboot(ctx: Context) = BootReceiver::class.java.enableComponent(ctx)
+    fun isRebootEnabled(ctx: Context) = ReschedulingReceiver::class.java.isComponentEnabled(ctx)
+    fun enableReboot(ctx: Context) = ReschedulingReceiver::class.java.enableComponent(ctx)
 }

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkRescheduling.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkRescheduling.kt
@@ -39,7 +39,7 @@ internal class WorkRescheduling @Inject constructor(
     private val scheduler: WorkScheduler,
     private val dao: WorkDao,
 ){
-    suspend fun reschedule(scope: CoroutineScope, work: Work?){
+    suspend fun reschedule(scope: CoroutineScope){
         dao.getPersistentWork().filterNotNull()
             .onEach {
                 it.forEach {

--- a/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
+++ b/bootlaces/src/main/java/com/candroid/bootlaces/WorkService.kt
@@ -58,7 +58,6 @@ import kotlin.properties.Delegates
 internal class WorkService: Service(), ComponentCallbacks2 {
     @Inject lateinit var foregroundProvider: Provider<ForegroundComponent.Builder>
     @Inject lateinit var intentFactory: IntentFactory
-    @Inject lateinit var workRescheduling: WorkRescheduling
     @Inject lateinit var mutex: Mutex
     @Inject lateinit var supervisor: CoroutineScope
     private lateinit var foreground: ForegroundActivator
@@ -102,7 +101,6 @@ internal class WorkService: Service(), ComponentCallbacks2 {
     private suspend fun handleRequest(intent: Intent?) = coroutineScope{
         val work: Work? = intent?.getParcelableExtra(Work.KEY_PARCEL)
         when (intent?.action ?: return@coroutineScope ) {
-            Actions.ACTION_RESCHEDULE.action -> workRescheduling.reschedule(this, work)
             Actions.ACTION_EXECUTE_WORKER.action -> work?.execute()
             else -> return@coroutineScope
         }


### PR DESCRIPTION
- move rescheduling functionality to BroadcastReceiver registered with BOOT_COMPLETE filter from WorkService.kt
- rename BootReceiver.kt to ReschedulingReceiver.kt
- remove Actions.ACTION_RESCHEDULE
- remove createReschedulingIntent function in IntentFactory.kt
- use goAsync in ReschedulingReceiver.kt inside of onReceive
- remove IntentFactory from ReschedulingReceiver.kt
- inject CoroutineScope in ReschedulingReceiver.kt